### PR TITLE
fix: fix typo in `epath`'s document `intro.md`

### DIFF
--- a/etils/epath/docs/intro.md
+++ b/etils/epath/docs/intro.md
@@ -71,7 +71,7 @@ path.suffix
 
 ### Convert `Path` -> `str`
 
-Some libraries are not compatibles with pathlib. If the library cannot be fixed
+Some libraries are not compatible with pathlib. If the library cannot be fixed
 to be [PEP 519](https://www.python.org/dev/peps/pep-0519/) compliant, you can
 convert pathlib object to `str` with `os.fspath`, like:
 


### PR DESCRIPTION
fix typo in `epath`'s document `intro.md`

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>