### PR TITLE
Implement `__fspath__` for `ResourcePath` instances

### DIFF
--- a/etils/epath/resource_utils.py
+++ b/etils/epath/resource_utils.py
@@ -60,7 +60,7 @@ class ResourcePath(zipfile.Path):
     Returns:
       the extracted path string.
     """
-    raise NotImplementedError('zipapp not supported. Please send us a PR.')
+    return str(self)
 
   if sys.version_info < (3, 10):
 


### PR DESCRIPTION
`zipfile.Path` and `zipp.Path` both implements `__str__` method to return a string representation of the `Path` instance which we can probably use here in `ResourcePath`

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>