### PR TITLE
fix typos and spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ from etils import ejax  # Jax utils
 ...
 ```
 
-Becauses each module is independent, only the minimal required libraries are
+Because each module is independent, only the minimal required libraries are
 imported (for example, importing `epy` won't suffer the cost of importing TF,
 jax,...)
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -309,7 +309,7 @@ out.grad
 
 ### Reduce verbosity (when possible)
 
-It is a good programing practice to give explicit code (good variable names,
+It is a good programming practice to give explicit code (good variable names,
 semantic type rather than builtins,...). However, sometimes it might actually
 make the API worse by adding verbosity without giving more information.
 

--- a/etils/ecolab/README.md
+++ b/etils/ecolab/README.md
@@ -69,7 +69,7 @@ The original string representation is still available through `repr(array)`.
 
 ### Collapsible logs on colab
 
-Sometimes, you might want to log verbose informations (e.g. the content of a
+Sometimes, you might want to log verbose information (e.g. the content of a
 file). To avoid polluting the logs, you can hide the logs inside a collapsible
 block (collapsed by default).
 


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.