### PR TITLE
Add a small tolerance to a matrix comparison test

### DIFF
--- a/etils/enp/interp_utils_test.py
+++ b/etils/enp/interp_utils_test.py
@@ -74,6 +74,7 @@ def test_interp_scalar(xnp: enp.NpModule):
           [1, 128 / 255, 0],
           [1, 0, 128 / 255],
       ]),
+      atol=1e-6,
   )
   np.testing.assert_allclose(
       enp.interp(vals, from_=(0, 255), to=(-1, 1)),


### PR DESCRIPTION
This test was failing on Arch with python3.11.

Tested with

```
 python -m build --wheel --skip-dependency-check --no-isolation
 python -m venv --system-site-packages test-env
  test-env/bin/python -m installer dist/*.whl
  test-env/bin/python -m pytest \
    --ignore etils/eapp/dataclass_flags_test.py \
    --ignore etils/ecolab/array_as_img_test.py \
    --ignore etils/ecolab/auto_display_utils_test.py \
    --ignore etils/ecolab/colab_utils_test.py \
    --ignore etils/ecolab/inplace_reload_test.py \
    --ignore etils/ecolab/lazy_imports_test.py \
    --ignore etils/ecolab/test_utils.py \
    --ignore etils/ecolab/inspects/attrs_test.py \
    --ignore etils/ecolab/inspects/html_helper_test.py \
    --ignore etils/ecolab/inspects/nodes_test.py \
    --ignore etils/edc/frozen_utils_test.py \
    --ignore etils/epy/lazy_imports_utils_test.py \
    --ignore etils/etree/tree_utils_test.py
```