### PR TITLE
Update gpath.py to fix a TypeError: unsupported operand type(s) for /…

### DIFF
--- a/etils/epath/gpath.py
+++ b/etils/epath/gpath.py
@@ -138,6 +138,15 @@ class _GPath(abstract_path.Path):
   def __repr__(self) -> str:
     return f'{type(self).__name__}({self._path_str!r})'
 
+  def __truediv__(self: _T, op:str) -> _T:                                                                                                                
+    uri_scheme = self._uri_scheme  
+    if uri_scheme:  # pylint: disable=using-constant-test
+      ret = self._PATH.join(f'{uri_scheme}://', *(list(self.parts[2:]) + [op]))
+    else: 
+      parts = (list(self.parts) + [op]) if self.parts else ['.',op]
+      ret = self._PATH.join(*parts)  
+      return type(self)(ret)  
+    
   def as_uri(self) -> str:
     if self._uri_scheme:  # s3://,...
       return self._path_str


### PR DESCRIPTION
…: 'PosixGPath' and 'str'

[ins] In [30]: import tensorflow_datasets as tfds
          ...: 
          ...: import tensorflow_text as tf_text
PARTS: PosixPath('/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets') PARTS: PosixGPath('/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets') ---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[30], line 1
----> 1 import tensorflow_datasets as tfds
      3 import tensorflow_text as tf_text

File /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets/__init__.py:43
     41 _TIMESTAMP_IMPORT_STARTS = time.time()
     42 from absl import logging
---> 43 import tensorflow_datasets.core.logging as _tfds_logging
     44 from tensorflow_datasets.core.logging import call_metadata as _call_metadata
     46 _metadata = _call_metadata.CallMetadata()

File /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets/core/__init__.py:22
     18 # Allow to use `tfds.core.Path` in dataset implementation which seems more
     19 # natural than having to import a third party module.
     20 from etils.epath import Path
---> 22 from tensorflow_datasets.core import community
     23 from tensorflow_datasets.core.dataset_builder import BeamBasedBuilder
     24 from tensorflow_datasets.core.dataset_builder import BuilderConfig

File /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets/core/community/__init__.py:18
      1 # coding=utf-8
      2 # Copyright 2023 The TensorFlow Datasets Authors.
      3 #
   (...)
     13 # See the License for the specific language governing permissions and
     14 # limitations under the License.
     16 """Community dataset API."""
---> 18 from tensorflow_datasets.core.community.huggingface_wrapper import mock_builtin_to_use_gfile
     19 from tensorflow_datasets.core.community.huggingface_wrapper import mock_huggingface_import
     20 from tensorflow_datasets.core.community.load import builder_cls_from_module

File /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets/core/community/huggingface_wrapper.py:31
     28 from unittest import mock
     30 from etils import epath
---> 31 from tensorflow_datasets.core import dataset_builder
     32 from tensorflow_datasets.core import dataset_info
     33 from tensorflow_datasets.core import download

File /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets/core/dataset_builder.py:33
     31 from absl import logging
     32 from etils import epath
---> 33 from tensorflow_datasets.core import constants
     34 from tensorflow_datasets.core import dataset_info
     35 from tensorflow_datasets.core import dataset_metadata

File /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tensorflow_datasets/core/constants.py:51
     49 # Filepath for mapping between TFDS datasets and PapersWithCode entries.
     50 PWC_FILENAME = 'tfds_to_pwc_links.json'
---> 51 PWC_LINKS_PATH = ( epath.resource_path('tensorflow_datasets') / f'scripts/documentation/{PWC_FILENAME}' )

TypeError: unsupported operand type(s) for /: 'PosixGPath' and 'str'