### PR TITLE
Bug fix for method `.relative_to` of `etils.epath.Path`

### DIFF
--- a/etils/epath/abstract_path.py
+++ b/etils/epath/abstract_path.py
@@ -155,6 +155,12 @@ class Path(pathlib.PurePosixPath):
     """Returns metadata for the file/directory."""
     raise NotImplementedError
 
+
+  def relative_to(self, other: PathLike) -> _T:
+    """Returns the current path relative to `other`."""
+    other_path = other if isinstance(other, self.__class__) else self._new(other)
+    return self.relative_to(other_path)
+
   # ====== Write methods ======
 
   @abstractmethod

--- a/etils/epath/gpath.py
+++ b/etils/epath/gpath.py
@@ -287,11 +287,6 @@ class _GPath(abstract_path.Path):
     """Returns metadata for the file/directory."""
     return self._backend.stat(self._path_str)
 
-  def relative_to(self: _P, other: PathLike) -> _P:
-    """Returns the current path relative to `other`."""
-    other_path = other if isinstance(other, self.__class__) else self._new(other)
-    return self.relative_to(other_path)
-
 
 @register.register_path_cls(_URI_PREFIXES)
 class PosixGPath(_GPath):

--- a/etils/epath/gpath.py
+++ b/etils/epath/gpath.py
@@ -287,6 +287,11 @@ class _GPath(abstract_path.Path):
     """Returns metadata for the file/directory."""
     return self._backend.stat(self._path_str)
 
+  def relative_to(self: _P, other: PathLike) -> _P:
+    """Returns the current path relative to `other`."""
+    other_path = other if isinstance(other, self.__class__) else self._new(other)
+    return self.relative_to(other_path)
+
 
 @register.register_path_cls(_URI_PREFIXES)
 class PosixGPath(_GPath):


### PR DESCRIPTION
Hi!  👋🏼 

Found out this bug when trying to run this simple code:

```python
from etils.epath import Path

Path('gs://bucket1/path1').relative_to('gs://bucket1')
```
It throws this error:

```
ValueError: 'gs://bucket1/path1' is not in the subpath of 'gs:/bucket1' OR one path is relative and the other is absolute.
```

I suspect it is because `.relative_to` method is inherited from the `PosixPath` from `pathlib`, which then converts `gs://` to `gs:/` (with a single `/`)

- This PR overrides the `relative_to` method for `epath.Path` objects to cast the method argument into a `Path` object if it arrives as a string before passing it to the `.relative_to` function from `pathlib.PosixPath` - and now this works

```python
>>> from etils.epath import Path
>>> Path('gs://bucket1/path1').relative_to(Path('gs://bucket1/'))
# PosixGPath('path1')
```

(cc @urabenst @cramshaw)