### PR TITLE
fix: resolve broken import in epath

### DIFF
--- a/etils/epath/resource_utils.py
+++ b/etils/epath/resource_utils.py
@@ -28,7 +28,7 @@ import zipfile
 from etils.epath import abstract_path
 from etils.epath import register
 from etils.epath.typing import PathLike  # pylint: disable=g-importing-member
-import importlib_resources
+import importlib.resources
 
 
 @register.register_path_cls


### PR DESCRIPTION
## Explanation of Error
When importing `epath` module, I get a `ModuleNotFoundError: No module named 'importlib_resources'` on Python versions 3.11 and 3.13.

## Reproduction of Error
```bash
# Installation of required packages
pip3 install etils typing_extensions
```
```python3
# Import
from etils import epath
```