### PR TITLE
Fix duplicate logging when better_logging is called multiple times

### DIFF
--- a/etils/eapp/logging_utils.py
+++ b/etils/eapp/logging_utils.py
@@ -62,6 +62,11 @@ class TqdmStream:
 
 def _better_logging() -> None:
   """Modify Python logging (internal)."""
+  logger = py_logging.getLogger()
+
+  if getattr(logger, "_better_logging_configured", False):
+    return
+  logger._better_logging_configured = True
   # If `absl.run` was not called (e.g. open source `pytest` tests)
   if not FLAGS.is_parsed():
     return

--- a/etils/eapp/tests/test_logging_utils.py
+++ b/etils/eapp/tests/test_logging_utils.py
@@ -1,0 +1,25 @@
+import logging
+
+from etils.eapp import better_logging
+
+
+def test_better_logging_idempotent():
+  logger = logging.getLogger()
+
+  # Reset possible state from other tests
+  if hasattr(logger, "_better_logging_configured"):
+    delattr(logger, "_better_logging_configured")
+
+  before = list(logger.handlers)
+
+  better_logging()
+  after_first = list(logger.handlers)
+
+  better_logging()
+  after_second = list(logger.handlers)
+
+  # First call may add handlers
+  assert len(after_first) >= len(before)
+
+  # Second call must not add any more handlers
+  assert len(after_second) == len(after_first)


### PR DESCRIPTION
Fixes #756

Make _better_logging idempotent to avoid adding duplicate logging handlers
when better_logging() is invoked more than once.
