### PR TITLE
Handle unknown UID/GID in _OsBackend.stat() gracefully

### DIFF
--- a/etils/epath/backend.py
+++ b/etils/epath/backend.py
@@ -232,8 +232,14 @@ class _OsPathBackend(Backend):
       import grp  # pylint: disable=g-import-not-at-top
       import pwd  # pylint: disable=g-import-not-at-top
 
-      owner = pwd.getpwuid(st.st_uid).pw_name
-      group = grp.getgrgid(st.st_gid).gr_name
+      try:
+        owner = pwd.getpwuid(st.st_uid).pw_name
+      except KeyError:
+        owner = str(st.st_uid)
+      try:
+        group = grp.getgrgid(st.st_gid).gr_name
+      except KeyError:
+        group = str(st.st_gid)
 
     return stat_utils.StatResult(
         is_directory=stat_lib.S_ISDIR(st.st_mode),


### PR DESCRIPTION
## Summary

- `_OsBackend.stat()` calls `pwd.getpwuid()` and `grp.getgrgid()` to resolve file owner/group names, but raises `KeyError` when the UID/GID is not present in `/etc/passwd` or `/etc/group`.
- This is common in container environments and shared filesystems (e.g. NFS) where files may be owned by UIDs that don't exist locally.
- Falls back to the numeric UID/GID as a string, consistent with how `ls -n` and other standard tools handle unknown UIDs.

Fixes #790

## Reproduction

```python
# In a container where files are owned by UID 1000 but /etc/passwd has no entry for it:
from etils import epath
p = epath.Path("/some/file/owned/by/unknown/uid")
p.stat()  # KeyError: 'getpwuid(): uid not found: 1000'
```

## Impact

This crashes downstream libraries like `orbax-checkpoint` which call `epath.Path.stat()` internally during checkpoint loading.

## Test plan

- Verified fix resolves the crash in orbax-checkpoint on a shared filesystem with unknown UIDs
- Existing behavior unchanged for known UIDs