### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/etils/ecolab/highlight_util.py
+++ b/etils/ecolab/highlight_util.py
@@ -45,8 +45,10 @@ def highlight_html(code: str) -> str:
   Returns:
     The HTML string representation
   """
-  theme = resource_utils.resource_import(
-      'static/highlight.css', module='etils.ecolab'
+  theme = html.escape(
+      resource_utils.resource_import(
+          'static/highlight.css', module='etils.ecolab'
+      )
   )
   # html
   html_str = """

--- a/etils/epy/re_utils.py
+++ b/etils/epy/re_utils.py
@@ -49,5 +49,8 @@ def reverse_fstring(pattern: str, string: str) -> dict[str, str] | None:
 
 @functools.cache
 def _pattern_cache(pattern: str) -> re.Pattern[str]:
-  pattern = re.sub(r'\{(?P<name>\w+)\}', r'(?P<\g<name>>.+)', pattern)
+  def _replace_named_group(m: re.Match[str]) -> str:
+    return f'(?P<{m.group(1)}>[^/]+)'
+  pattern = re.escape(pattern)
+  pattern = re.sub(r'\\\{(?P<name>\w+)\\\}', _replace_named_group, pattern)
   return re.compile(pattern)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `etils/epy/re_utils.py:L58`

In `etils/epy/re_utils.py`, the `_pattern_cache` function converts f-string patterns to regex patterns by replacing `{name}` with `(?P<name>.+)`. However, if the input `pattern` contains other special regex characters (e.g., `.`, `*`, `?`, `[]`, `()`, etc.), they are passed directly to `re.compile` without escaping. This can lead to unexpected regex behavior, performance issues (ReDoS), or incorrect matching. While the primary use case is controlled patterns, if user input is ever passed to `reverse_fstring`, it could be exploited. Additionally, the `.+` quantifier is greedy and may cause catastrophic backtracking with certain inputs.

## Solution

Escape the literal parts of the pattern before substituting named groups. Consider using `re.escape()` on the static parts of the pattern, or validate that the pattern only contains expected f-string placeholders. Also consider using `[^/]+` or a more specific character class instead of `.+` to reduce ReDoS risk.

## Changes

- `etils/epy/re_utils.py` (modified)
- `etils/ecolab/highlight_util.py` (modified)